### PR TITLE
fix(colors):Properly use ThemeResources

### DIFF
--- a/src/library/Uno.Material/Styles/Application/Colors.xaml
+++ b/src/library/Uno.Material/Styles/Application/Colors.xaml
@@ -45,90 +45,92 @@
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
 
+	
+
 	<!-- Global brushes -->
 	<SolidColorBrush x:Key="PrimaryBrush"
-					 Color="{StaticResource PrimaryColor}"/>
+					 Color="{ThemeResource PrimaryColor}"/>
 	<SolidColorBrush x:Key="PrimaryVariantDarkBrush"
-					 Color="{StaticResource PrimaryVariantDarkColor}"/>
+					 Color="{ThemeResource PrimaryVariantDarkColor}"/>
 	<SolidColorBrush x:Key="PrimaryVariantLightBrush"
-					 Color="{StaticResource PrimaryVariantLightColor}"/>
+					 Color="{ThemeResource PrimaryVariantLightColor}"/>
 	<SolidColorBrush x:Key="SecondaryBrush"
-					 Color="{StaticResource SecondaryColor}"/>
+					 Color="{ThemeResource SecondaryColor}"/>
 	<SolidColorBrush x:Key="SecondaryVariantDarkBrush"
-					 Color="{StaticResource SecondaryVariantDarkColor}"/>
+					 Color="{ThemeResource SecondaryVariantDarkColor}"/>
 	<SolidColorBrush x:Key="SecondaryVariantLightBrush"
-					 Color="{StaticResource SecondaryVariantLightColor}"/>
+					 Color="{ThemeResource SecondaryVariantLightColor}"/>
 	<SolidColorBrush x:Key="BackgroundBrush"
-					 Color="{StaticResource BackgroundColor}"/>
+					 Color="{ThemeResource BackgroundColor}"/>
 	<SolidColorBrush x:Key="SurfaceBrush"
-					 Color="{StaticResource SurfaceColor}"/>
+					 Color="{ThemeResource SurfaceColor}"/>
 	<SolidColorBrush x:Key="ErrorBrush"
-					 Color="{StaticResource ErrorColor}"/>
+					 Color="{ThemeResource ErrorColor}"/>
 
 	<!-- OnPrimary Brushes -->
 	<!-- Only opacity should differ -->
 	<SolidColorBrush x:Key="OnPrimaryBrush"
-					 Color="{StaticResource OnPrimaryColor}"
+					 Color="{ThemeResource OnPrimaryColor}"
 					 Opacity="1.0"/>
 	<SolidColorBrush x:Key="OnPrimaryMediumBrush"
-					 Color="{StaticResource OnPrimaryColor}"
+					 Color="{ThemeResource OnPrimaryColor}"
 					 Opacity="0.74"/>
 	<SolidColorBrush x:Key="OnPrimaryDisabledBrush"
-					 Color="{StaticResource OnPrimaryColor}"
+					 Color="{ThemeResource OnPrimaryColor}"
 					 Opacity="0.38"/>
 	<SolidColorBrush x:Key="OnPrimaryHoverBrush"
-					 Color="{StaticResource OnPrimaryColor}"
+					 Color="{ThemeResource OnPrimaryColor}"
 					 Opacity="0.04"/>
 	<SolidColorBrush x:Key="OnPrimaryFocusedBrush"
-					 Color="{StaticResource OnPrimaryColor}"
+					 Color="{ThemeResource OnPrimaryColor}"
 					 Opacity="0.12"/>
 	<SolidColorBrush x:Key="OnPrimaryPressedBrush"
-					 Color="{StaticResource OnPrimaryColor}"
+					 Color="{ThemeResource OnPrimaryColor}"
 					 Opacity="0.10"/>
 	<SolidColorBrush x:Key="OnPrimaryDraggedBrush"
-					 Color="{StaticResource OnPrimaryColor}"
+					 Color="{ThemeResource OnPrimaryColor}"
 					 Opacity="0.08"/>
 	<SolidColorBrush x:Key="OnPrimarySelectedBrush"
-					 Color="{StaticResource OnPrimaryColor}"
+					 Color="{ThemeResource OnPrimaryColor}"
 					 Opacity="0.08"/>
 
 	<!-- OnSecondary Brushes -->
 	<!-- Only opacity should differ -->
 	<SolidColorBrush x:Key="OnSecondaryBrush"
-					 Color="{StaticResource OnSecondaryColor}"
+					 Color="{ThemeResource OnSecondaryColor}"
 					 Opacity="1.0"/>
 	<SolidColorBrush x:Key="OnSecondaryMediumBrush"
-					 Color="{StaticResource OnSecondaryColor}"
+					 Color="{ThemeResource OnSecondaryColor}"
 					 Opacity="0.74"/>
 	<SolidColorBrush x:Key="OnSecondaryDisabledBrush"
-					 Color="{StaticResource OnSecondaryColor}"
+					 Color="{ThemeResource OnSecondaryColor}"
 					 Opacity="0.38"/>
 
 	<!-- OnSurface Brushes -->
 	<!-- Only opacity should differ -->
 	<SolidColorBrush x:Key="OnSurfaceBrush"
-					 Color="{StaticResource OnSurfaceColor}"
+					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="1.0"/>
 	<SolidColorBrush x:Key="OnSurfaceMediumBrush"
-					 Color="{StaticResource OnSurfaceColor}"
+					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="0.74"/>
 	<SolidColorBrush x:Key="OnSurfaceDisabledBrush"
-					 Color="{StaticResource OnSurfaceColor}"
+					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="0.38"/>
 	<SolidColorBrush x:Key="OnSurfaceHoverBrush"
-					 Color="{StaticResource OnSurfaceColor}"
+					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="0.04"/>
 	<SolidColorBrush x:Key="OnSurfaceFocusedBrush"
-					 Color="{StaticResource OnSurfaceColor}"
+					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="0.12"/>
 	<SolidColorBrush x:Key="OnSurfacePressedBrush"
-					 Color="{StaticResource OnSurfaceColor}"
+					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="0.10"/>
 	<SolidColorBrush x:Key="OnSurfaceDraggedBrush"
-					 Color="{StaticResource OnSurfaceColor}"
+					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="0.08"/>
 	<SolidColorBrush x:Key="OnSurfaceSelectedBrush"
-					 Color="{StaticResource OnSurfaceColor}"
+					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="0.08"/>
 
 	<!-- OnSurfacePrimary Brushes -->

--- a/src/library/Uno.Material/Styles/Controls/Button.xaml
+++ b/src/library/Uno.Material/Styles/Controls/Button.xaml
@@ -16,22 +16,22 @@
 
 	<!-- Contained Button Colors and Variables -->
 	<SolidColorBrush x:Key="ButtonContainedBackgroundColor"
-					 Color="{StaticResource PrimaryColor}" />
+					 Color="{ThemeResource PrimaryColor}" />
 	<SolidColorBrush x:Key="ButtonContainedLabelColor"
-					 Color="{StaticResource OnPrimaryColor}" />
+					 Color="{ThemeResource OnPrimaryColor}" />
 
 	<!-- Outlined Button Variables -->
 	<SolidColorBrush x:Key="ButtonOutlinedBackgroundColor"
-					 Color="{StaticResource OnPrimaryColor}" />
+					 Color="{ThemeResource OnPrimaryColor}" />
 	<SolidColorBrush x:Key="ButtonOutlinedStrokeColor"
-					 Color="{StaticResource PrimaryColor}" />
+					 Color="{ThemeResource PrimaryColor}" />
 	<SolidColorBrush x:Key="ButtonOutlinedLabelColor"
-					 Color="{StaticResource PrimaryColor}" />
+					 Color="{ThemeResource PrimaryColor}" />
 	<Thickness x:Key="ButtonOutlinedStrokeWidth">1</Thickness>
 
 	<!-- Text Button Variables -->
 	<SolidColorBrush x:Key="ButtonTextLabelColor"
-					 Color="{StaticResource PrimaryColor}" />
+					 Color="{ThemeResource PrimaryColor}" />
 
 	<!-- All Button Variables -->
 	<CornerRadius x:Key="ButtonBorderRadius">4</CornerRadius>
@@ -49,15 +49,15 @@
 		<Setter Property="BorderThickness"
 				Value="0" />
 		<Setter Property="Padding"
-				Value="{StaticResource ButtonPadding}" />
+				Value="{ThemeResource ButtonPadding}" />
 		<!--<Setter Property="CornerRadius"
 				Value="{StaticResource ButtonBorderRadius}" />-->
 		<Setter Property="MinHeight"
 				Value="40" />
 		<Setter Property="FontFamily"
-				Value="{StaticResource ButtonFontFamily}" />
+				Value="{ThemeResource ButtonFontFamily}" />
 		<Setter Property="FontSize"
-				Value="{StaticResource ButtonFontSize}" />
+				Value="{ThemeResource ButtonFontSize}" />
 		<Setter Property="UseSystemFocusVisuals"
 				Value="True" />
 		<Setter Property="Template">
@@ -107,9 +107,9 @@
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
 										<Setter Target="Root.Background"
-												Value="{StaticResource OnSurfaceDisabledBrush}" />
+												Value="{ThemeResource OnSurfaceDisabledBrush}" />
 										<Setter Target="ContentPresenter.Foreground"
-												Value="{StaticResource OnSurfaceMediumBrush}" />
+												Value="{ThemeResource OnSurfaceMediumBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>

--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/ButtonSamplePage.xaml
@@ -6,13 +6,13 @@
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  mc:Ignorable="d">
 
-	<StackPanel BorderBrush="{StaticResource Color04Brush}"
+	<StackPanel BorderBrush="{StaticResource OnSurfaceBrush}"
 				BorderThickness="1"
 				Margin="12">
 		<TextBlock Text="BUTTONS"
 				   FontSize="20"
 				   FontWeight="Bold"
-				   Foreground="{StaticResource PrimaryColor01Brush}"
+				   Foreground="{StaticResource PrimaryBrush}"
 				   Margin="12" />
 
 		<Button Content="CONTAINED"

--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/SamplesPage.xaml
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/SamplesPage.xaml
@@ -7,17 +7,16 @@
 	  xmlns:toolkit="using:Uno.UI.Toolkit"
 	  mc:Ignorable="d">
 
-	<Grid toolkit:VisibleBoundsPadding.PaddingMask="All">
+	<Grid toolkit:VisibleBoundsPadding.PaddingMask="All"
+		  Background="{StaticResource BackgroundBrush}">
 		<NavigationView x:Name="NavView"
 						ItemInvoked="NavView_ItemInvoked"
 						Loaded="NavView_Loaded"
 						PaneTitle="Uno Material"
 						Margin="0,12,0,0"
-						IsSettingsVisible="true"
 						IsTabStop="False"
 						PaneDisplayMode="Auto"
 						IsBackButtonVisible="Collapsed">
-
 			<!-- Search Box -->
 			<NavigationView.AutoSuggestBox>
 				<AutoSuggestBox x:Name="SearchBox"

--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/SamplesPage.xaml.cs
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/SamplesPage.xaml.cs
@@ -1,19 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
 using Uno.Material.Samples.Content.Controls;
 using Uno.Material.Samples.Content.Styles;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 
 
 namespace Uno.Material.Samples
@@ -27,10 +17,19 @@ namespace Uno.Material.Samples
 
         private void NavView_Loaded(object sender, RoutedEventArgs e)
         {
-            // Adding NavigationView items in code behind
+#if WINDOWS_UWP
+			NavView.IsSettingsVisible = true;
+			// Change the settings text to toggle the theme
+			var settingsItem = (NavigationViewItem)NavView.SettingsItem;
+			settingsItem.Content = "Toggle Light/Dark theme";
+#else
+			NavView.IsSettingsVisible = false;
+#endif
 
-            // Styles
-            NavView.MenuItems.Add(new NavigationViewItemHeader() { Content = "Styles" });
+			// Adding NavigationView items in code behind
+
+			// Styles
+			NavView.MenuItems.Add(new NavigationViewItemHeader() { Content = "Styles" });
             NavView.MenuItems.Add(new NavigationViewItem()
             { Content = "Colors Overview", Icon = new SymbolIcon(Symbol.Next), Tag = "ColorsSamplePage" });
             NavView.MenuItems.Add(new NavigationViewItemSeparator());
@@ -63,18 +62,36 @@ namespace Uno.Material.Samples
 
         private void NavView_ItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
         {
-            // TO-DO : Verify if we want a SettingPage
-            //if (args.IsSettingsInvoked)
-            //{
-            //    ContentFrame.Navigate(typeof(SettingsPage));
-            //}
-            //else
-            //{
-                // Find NavigationViewItem with Content that equals InvokedItem
-                var item = sender.MenuItems.OfType<NavigationViewItem>().First(x => (string)x.Content == (string)args.InvokedItem);
-                NavView_Navigate(item as NavigationViewItem);
-            //}
+            if (args.IsSettingsInvoked)
+            {
+#if WINDOWS_UWP
+				ToggleTheme();
+				void ToggleTheme()
+				{
+					// Set theme for window root.
+					if (Window.Current.Content is FrameworkElement frameworkElement)
+					{
+						if (frameworkElement.ActualTheme == ElementTheme.Dark)
+						{
+							frameworkElement.RequestedTheme = ElementTheme.Light;
+						}
+						else
+						{
+							frameworkElement.RequestedTheme = ElementTheme.Dark;
+						}
+					}
+				}
+#endif
+			}
+            else
+            {
+              // Find NavigationViewItem with Content that equals InvokedItem
+              var item = sender.MenuItems.OfType<NavigationViewItem>().First(x => (string)x.Content == (string)args.InvokedItem);
+              NavView_Navigate(item as NavigationViewItem);
+            }
         }
+
+
 
         private void NavView_Navigate(NavigationViewItem item)
         {


### PR DESCRIPTION
fix(colors):Properly use ThemeResources instead of StaticResource to enable changing the theme at runtime

GitHub Issue: #7 

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Other... Please describe:


## Description

<!-- (Please describe the changes that this PR introduces.) -->
Theme was not changing properly at runtime because StaticResources are not reevaluated.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [ ] Tested Android
- [ ] Tested WASM
- [x] Contains **No** breaking changes

- If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->