### PR TITLE
Fix problem where Uno wasn't available in the Uno.Material library and only in the UWP Sample

### DIFF
--- a/src/library/Uno.Material/Uno.Material.csproj
+++ b/src/library/Uno.Material/Uno.Material.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/2.0.54">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid90;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid90;uap10.0.17763</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid90' or '$(TargetFramework)'=='netstandard2.0'">
+  <ItemGroup>
     <PackageReference Include="Uno.UI" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.UWP/Uno.Material.Samples.UWP.csproj
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.UWP/Uno.Material.Samples.UWP.csproj
@@ -12,7 +12,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-    <PackageReference Include="Uno.Core" Version="1.29.0" />
     <PackageReference Include="Uno.UI">
       <Version>2.2.0</Version>
     </PackageReference>


### PR DESCRIPTION
GitHub Issue: #9 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description
Uno.UI is now installed in UWP for the library + bumped UAP to 17763 to be in line with Uno.

## PR Checklist 
- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->