### PR TITLE
Fix Darkmode colors : Radio Button, CheckBox, ToggleSwitch, ComboBox

### DIFF
--- a/src/library/Uno.Material/Styles/Application/Colors.xaml
+++ b/src/library/Uno.Material/Styles/Application/Colors.xaml
@@ -70,6 +70,8 @@
 					 Color="{ThemeResource ErrorColor}"/>
 	<SolidColorBrush x:Key="OnErrorBrush"
 					 Color="{ThemeResource OnErrorColor}"/>
+	<SolidColorBrush x:Key="OnBackgroundBrush"
+					 Color="{ThemeResource OnBackgroundColor}"/>
 	<SolidColorBrush x:Key="OverlayBrush"
 					 Color="{ThemeResource OverlayColor}"/>
 

--- a/src/library/Uno.Material/Styles/Application/SelectionControlColors.xaml
+++ b/src/library/Uno.Material/Styles/Application/SelectionControlColors.xaml
@@ -13,28 +13,28 @@
 	</ResourceDictionary.MergedDictionaries>
 
 	<SolidColorBrush x:Key="SelectControlBackgroundColor"
-					 Color="{StaticResource PrimaryColor}" />
+					 Color="{ThemeResource PrimaryColor}" />
 	<SolidColorBrush x:Key="SelectControlIndicatorColor"
-					 Color="{StaticResource OnPrimaryColor}" />
+					 Color="{ThemeResource OnPrimaryColor}" />
 	<SolidColorBrush x:Key="SelectControlStrokeColor"
-					 Color="{StaticResource OnSurfaceColor}"
+					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="0.74" />
 	<SolidColorBrush x:Key="SelectControlToggleOnButtonColor"
-					 Color="{StaticResource PrimaryColor}" />
+					 Color="{ThemeResource PrimaryColor}" />
 	<!-- TODO: This is the OnPrimaryDisabledBrush, remove when brush issue #41 is fixed -->
 	<SolidColorBrush x:Key="SelectControlToggleOnBackgroundColor"
 					 Color="#615B4CF5" />
 	<SolidColorBrush x:Key="SelectControlToggleOnFocusBackgroundColor"
-					 Color="{StaticResource PrimaryColor}"
+					 Color="{ThemeResource PrimaryColor}"
 					 Opacity="0.1" />
 	<!-- TODO: This is the OnSurfaceHoverBrush, remove when brush issue #41 is fixed without oPACITY -->
 	<SolidColorBrush x:Key="SelectControlToggleOffButtonColor"
-					 Color="#F5F5F5" />
+					 Color="{ThemeResource BackgroundColor}" />
 	<SolidColorBrush x:Key="SelectControlToggleOffHoverButtonColor"
-					 Color="{StaticResource OnSurfaceColor}"
+					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="0.05" />
 	<SolidColorBrush x:Key="SelectControlToggleOffFocusButtonColor"
-					 Color="{StaticResource OnSurfaceColor}"
+					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="0.08" />
 	<!-- TODO: This is the OnSurfaceDisabledBrush, remove when brush issue #41 is fixed -->
 	<SolidColorBrush x:Key="SelectControlToggleOffBackgroundColor"

--- a/src/library/Uno.Material/Styles/Controls/ComboBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ComboBox.xaml
@@ -27,16 +27,16 @@
 					ResourceKey="OnSurfaceFocusedBrush" />
 
 	<StaticResource x:Key="ComboBoxArrowForegroundThemeBrush"
-					ResourceKey="OnSecondaryMediumBrush" />
+					ResourceKey="OnBackgroundBrush" />
 
-	<SolidColorBrush x:Key="ComboBoxForegroundThemeBrush"
-					 Color="{ThemeResource OnSecondaryColor}" />
+	<StaticResource x:Key="ComboBoxForegroundThemeBrush"
+					ResourceKey="OnBackgroundBrush" />
 
-	<StaticResource x:Key="ComboBoxFocusedBackgroundThemeBrush"
-					ResourceKey="OnSecondaryMediumBrush" />
+	<SolidColorBrush x:Key="ComboBoxPlaceholderTextColor"
+					 Color="{ThemeResource OnBackgroundColor}"
+					 Opacity="0.74" />
 
-	<StaticResource x:Key="ComboBoxPlaceholderTextForegroundThemeBrush"
-					ResourceKey="OnSecondaryMediumBrush" />
+	<CornerRadius x:Key="ComboBoxBorderRadius">4</CornerRadius>
 
 	<!-- Style -->
 	<Style x:Key="MaterialComboBoxItemStyle"
@@ -180,7 +180,7 @@
 				Value="{StaticResource MaterialComboBoxItemStyle}" />
 		<xamarin:Setter Property="uno:ComboBox.DropDownPreferredPlacement"
 						Value="Below" />
-		
+
 		<Setter Property="ItemsPanel">
 			<Setter.Value>
 				<ItemsPanelTemplate>
@@ -192,7 +192,8 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="ComboBox">
-					<Grid x:Name="RootGrid">
+					<Grid x:Name="RootGrid"
+						  CornerRadius="{StaticResource ComboBoxBorderRadius}">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
 								<VisualState x:Name="Normal" />
@@ -285,7 +286,7 @@
 						<!-- Elevated View -->
 						<toolkit:ElevatedView Background="{ThemeResource ComboBoxBackgroundColorBrush}"
 											  HorizontalAlignment="Stretch"
-											  CornerRadius="4"
+											  CornerRadius="{StaticResource ComboBoxBorderRadius}"
 											  Elevation="8"
 											  win:BorderBrush="{StaticResource ComboBoxBorderBrush}"
 											  win:BorderThickness="1">
@@ -334,7 +335,7 @@
 											   Text="{TemplateBinding PlaceholderText}"
 											   Style="{StaticResource Body2}"
 											   MaxLines="1"
-											   Foreground="{ThemeResource ComboBoxPlaceholderTextForegroundThemeBrush}" />
+											   Foreground="{ThemeResource ComboBoxPlaceholderTextColor}" />
 								</ContentPresenter>
 
 								<!-- PlaceholderTextBlock -->
@@ -398,7 +399,7 @@
 									</Border>
 								</Popup>
 							</Grid>
-						</toolkit:ElevatedView> 
+						</toolkit:ElevatedView>
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

Colors were off when looking at the app in dark mode for the Radio Button, CheckBox, ToggleSwitch and ComboBox samples.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [ ] Tested WASM
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->