### PR TITLE
fix(droid): nav-view loaded again on resume

### DIFF
--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/SamplesPage.xaml.cs
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/SamplesPage.xaml.cs
@@ -17,6 +17,12 @@ namespace Uno.Material.Samples
 
 		private void NavView_Loaded(object sender, RoutedEventArgs e)
 		{
+			if (NavView.MenuItems.Any())
+			{
+				// on android, this can also fire when the app is resumed from background ("alt-tabbed back")
+				return;
+			}
+
 #if WINDOWS_UWP
 			NavView.IsSettingsVisible = true;
 			// Change the settings text to toggle the theme


### PR DESCRIPTION
GitHub Issue: #120

## PR Type
What kind of change does this PR introduce?

- Bugfix

## Description
fixed nav-view loaded again on resume

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
NavigationView.Loaded event is proc'd every time the app is resumed from background. And, we just keep adding the entire list menu items again. _It seems that the listview isnt too happy when items with same contents (`Content, Icon, Tag`) are added again, especially when they are in, what is presumably, RecyclerView's zone._
resolved: #120