### PR TITLE
fix(flicker): Using transitions setters to avoid flickers on page load

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/CheckBox.xaml
+++ b/src/library/Uno.Material/Styles/Controls/CheckBox.xaml
@@ -46,68 +46,9 @@
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CombinedStates">
 
-								<VisualState x:Name="UncheckedNormal">
-									<xamarin:Storyboard>
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleX"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleY"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-										
-										<android:DoubleAnimation Storyboard.TargetName="PressRing"
-																 Storyboard.TargetProperty="Opacity"
-																 Duration="0:0:0.5"
-																 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																 From="1"
-																 To="0" />
-
-										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
-																	   Storyboard.TargetName="PressRing">
-											<EasingDoubleKeyFrame KeyTime="0"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.2"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.4"
-																  Value="0" />
-										</DoubleAnimationUsingKeyFrames>
-									</xamarin:Storyboard>
-								</VisualState>
+								<VisualState x:Name="UncheckedNormal" />
 
 								<VisualState x:Name="UncheckedPointerOver">
-									<Storyboard>
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleX"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleY"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-
-										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
-																	   Storyboard.TargetName="PressRing">
-											<EasingDoubleKeyFrame KeyTime="0"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.2"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.4"
-																  Value="0" />
-										</DoubleAnimationUsingKeyFrames>
-									</Storyboard>
-
 									<VisualState.Setters>
 										<Setter Target="FocusRing.Fill"
 												Value="{ThemeResource SelectControlToggleOffHoverButtonColor}" />
@@ -131,39 +72,6 @@
 								</VisualState>
 
 								<VisualState x:Name="CheckedNormal">
-									<xamarin:Storyboard>
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleX"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleY"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-
-										<android:DoubleAnimation Storyboard.TargetName="PressRing"
-																 Storyboard.TargetProperty="Opacity"
-																 Duration="0:0:0.5"
-																 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																 From="1"
-																 To="0" />
-
-										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
-																	   Storyboard.TargetName="PressRing">
-											<EasingDoubleKeyFrame KeyTime="0"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.2"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.4"
-																  Value="0" />
-										</DoubleAnimationUsingKeyFrames>
-									</xamarin:Storyboard>
-
 									<VisualState.Setters>
 										<Setter Target="BackgroundBorder.Background"
 												Value="{ThemeResource SelectControlBackgroundColor}" />
@@ -175,32 +83,6 @@
 								</VisualState>
 
 								<VisualState x:Name="CheckedPointerOver">
-									<Storyboard>
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleX"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleY"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-
-										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
-																	   Storyboard.TargetName="PressRing">
-											<EasingDoubleKeyFrame KeyTime="0"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.2"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.4"
-																  Value="0" />
-										</DoubleAnimationUsingKeyFrames>
-									</Storyboard>
-
 									<VisualState.Setters>
 										<Setter Target="BackgroundBorder.Background"
 												Value="{ThemeResource SelectControlBackgroundColor}" />
@@ -242,39 +124,6 @@
 								</VisualState>
 
 								<VisualState x:Name="IndeterminateNormal">
-									<xamarin:Storyboard>
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleX"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleY"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-
-										<android:DoubleAnimation Storyboard.TargetName="PressRing"
-																 Storyboard.TargetProperty="Opacity"
-																 Duration="0:0:0.5"
-																 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-																 From="1"
-																 To="0" />
-										
-										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
-																	   Storyboard.TargetName="PressRing">
-											<EasingDoubleKeyFrame KeyTime="0"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.2"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.4"
-																  Value="0" />
-										</DoubleAnimationUsingKeyFrames>
-									</xamarin:Storyboard>
-
 									<VisualState.Setters>
 										<Setter Target="BackgroundBorder.Background"
 												Value="{ThemeResource SelectControlBackgroundColor}" />
@@ -286,32 +135,6 @@
 								</VisualState>
 
 								<VisualState x:Name="IndeterminatePointerOver">
-									<Storyboard>
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleX"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-
-										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
-														 Storyboard.TargetProperty="ScaleY"
-														 Duration="0:0:0.4"
-														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
-														 From="0"
-														 To="1" />
-
-										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
-																	   Storyboard.TargetName="PressRing">
-											<EasingDoubleKeyFrame KeyTime="0"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.2"
-																  Value="0.5" />
-											<EasingDoubleKeyFrame KeyTime="0:0:0.4"
-																  Value="0" />
-										</DoubleAnimationUsingKeyFrames>
-									</Storyboard>
-
 									<VisualState.Setters>
 										<Setter Target="BackgroundBorder.Background"
 												Value="{ThemeResource SelectControlBackgroundColor}" />
@@ -351,6 +174,226 @@
 												Value="1" />
 									</VisualState.Setters>
 								</VisualState>
+
+								<VisualStateGroup.Transitions>
+									<VisualTransition From="UncheckedNormal"
+													  To="UncheckedPressed">
+										<Storyboard>
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleX"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleY"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<android:DoubleAnimation Storyboard.TargetName="PressRing"
+																	 Storyboard.TargetProperty="Opacity"
+																	 Duration="0:0:0.5"
+																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+																	 From="1"
+																	 To="0" />
+
+											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
+																		   Storyboard.TargetName="PressRing">
+												<EasingDoubleKeyFrame KeyTime="0"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.2"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.4"
+																	  Value="0" />
+											</DoubleAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>
+									
+									<VisualTransition From="UncheckedPointerOver"
+													  To="UncheckedPressed">
+										<Storyboard>
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleX"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleY"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<android:DoubleAnimation Storyboard.TargetName="PressRing"
+																	 Storyboard.TargetProperty="Opacity"
+																	 Duration="0:0:0.5"
+																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+																	 From="1"
+																	 To="0" />
+
+											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
+																		   Storyboard.TargetName="PressRing">
+												<EasingDoubleKeyFrame KeyTime="0"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.2"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.4"
+																	  Value="0" />
+											</DoubleAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>
+									
+									<VisualTransition From="CheckedNormal"
+													  To="CheckedPressed">
+										<Storyboard>
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleX"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleY"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<android:DoubleAnimation Storyboard.TargetName="PressRing"
+																	 Storyboard.TargetProperty="Opacity"
+																	 Duration="0:0:0.5"
+																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+																	 From="1"
+																	 To="0" />
+
+											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
+																		   Storyboard.TargetName="PressRing">
+												<EasingDoubleKeyFrame KeyTime="0"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.2"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.4"
+																	  Value="0" />
+											</DoubleAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>
+									
+									<VisualTransition From="CheckedPointerOver"
+													  To="CheckedPressed">
+										<Storyboard>
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleX"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleY"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<android:DoubleAnimation Storyboard.TargetName="PressRing"
+																	 Storyboard.TargetProperty="Opacity"
+																	 Duration="0:0:0.5"
+																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+																	 From="1"
+																	 To="0" />
+
+											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
+																		   Storyboard.TargetName="PressRing">
+												<EasingDoubleKeyFrame KeyTime="0"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.2"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.4"
+																	  Value="0" />
+											</DoubleAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>
+									
+									<VisualTransition From="IndeterminateNormal"
+													  To="IndeterminatePressed">
+
+										<Storyboard>
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleX"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleY"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<android:DoubleAnimation Storyboard.TargetName="PressRing"
+																	 Storyboard.TargetProperty="Opacity"
+																	 Duration="0:0:0.5"
+																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+																	 From="1"
+																	 To="0" />
+
+											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
+																		   Storyboard.TargetName="PressRing">
+												<EasingDoubleKeyFrame KeyTime="0"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.2"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.4"
+																	  Value="0" />
+											</DoubleAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>
+									
+									<VisualTransition From="IndeterminatePointerOver"
+													  To="IndeterminatePressed">
+
+										<Storyboard>
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleX"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+															 Storyboard.TargetProperty="ScaleY"
+															 Duration="0:0:0.4"
+															 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+															 From="0"
+															 To="1" />
+
+											<android:DoubleAnimation Storyboard.TargetName="PressRing"
+																	 Storyboard.TargetProperty="Opacity"
+																	 Duration="0:0:0.5"
+																	 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+																	 From="1"
+																	 To="0" />
+
+											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(FrameworkElement.Opacity)"
+																		   Storyboard.TargetName="PressRing">
+												<EasingDoubleKeyFrame KeyTime="0"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.2"
+																	  Value="0.5" />
+												<EasingDoubleKeyFrame KeyTime="0:0:0.4"
+																	  Value="0" />
+											</DoubleAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>
+								</VisualStateGroup.Transitions>
 							</VisualStateGroup>
 
 							<VisualStateGroup x:Name="FocusStates">

--- a/src/library/Uno.Material/Styles/Controls/RadioButton.xaml
+++ b/src/library/Uno.Material/Styles/Controls/RadioButton.xaml
@@ -43,7 +43,9 @@
 						  Background="Transparent">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
-								<VisualState x:Name="Normal" />
+								<VisualState x:Name="Normal">
+								</VisualState>
+
 								<VisualState x:Name="PointerOver" />
 
 								<VisualState x:Name="Pressed">
@@ -59,12 +61,12 @@
 												Value="0.5" />
 									</VisualState.Setters>
 								</VisualState>
-							</VisualStateGroup>
 
-							<VisualStateGroup x:Name="CheckStates">
 
-								<VisualState x:Name="Checked">
-									<Storyboard>
+								<VisualStateGroup.Transitions>
+									<VisualTransition From="Normal"
+													  To="Pressed">
+										<Storyboard>
 										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
 														 Storyboard.TargetProperty="ScaleX"
 														 Duration="0:0:0.4"
@@ -85,7 +87,7 @@
 																 EasingFunction="{StaticResource Material_EaseInOutFunction}"
 																 From="1"
 																 To="0" />
-										
+
 										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
 																	   Storyboard.TargetName="PressRing">
 											<EasingDoubleKeyFrame KeyTime="0"
@@ -96,7 +98,48 @@
 																  Value="0" />
 										</DoubleAnimationUsingKeyFrames>
 									</Storyboard>
-									
+									</VisualTransition>
+									<VisualTransition From="PointerOver"
+													  To="Pressed">
+										<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+														 Storyboard.TargetProperty="ScaleX"
+														 Duration="0:0:0.4"
+														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+														 From="0"
+														 To="1" />
+
+										<DoubleAnimation Storyboard.TargetName="PressRingTransform"
+														 Storyboard.TargetProperty="ScaleY"
+														 Duration="0:0:0.4"
+														 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+														 From="0"
+														 To="1" />
+
+										<android:DoubleAnimation Storyboard.TargetName="PressRing"
+																 Storyboard.TargetProperty="Opacity"
+																 Duration="0:0:0.5"
+																 EasingFunction="{StaticResource Material_EaseInOutFunction}"
+																 From="1"
+																 To="0" />
+
+										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
+																	   Storyboard.TargetName="PressRing">
+											<EasingDoubleKeyFrame KeyTime="0"
+																  Value="0.5" />
+											<EasingDoubleKeyFrame KeyTime="0:0:0.2"
+																  Value="0.5" />
+											<EasingDoubleKeyFrame KeyTime="0:0:0.4"
+																  Value="0" />
+										</DoubleAnimationUsingKeyFrames>
+									</Storyboard>
+									</VisualTransition>
+								</VisualStateGroup.Transitions>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="CheckStates">
+
+								<VisualState x:Name="Checked">
 									<VisualState.Setters>
 										<Setter Target="OuterEllipse.Stroke"
 												Value="{StaticResource SelectControlBackgroundColor}" />


### PR DESCRIPTION
GitHub Issue: #102

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

- Using transitions setters to avoid flickers on page loading a checked checkbox and radiobutton
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [x] Tested Android
- [ ] Tested WASM
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)



## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->