### PR TITLE
fix(BottomBarNavigation): breaks on second visit

### DIFF
--- a/src/library/Uno.Material/Controls/BottomNavigationBar.cs
+++ b/src/library/Uno.Material/Controls/BottomNavigationBar.cs
@@ -15,7 +15,7 @@ namespace Uno.Material.Controls
 			set => SetValue(ItemsProperty, value);
 		}
 
-		public readonly DependencyProperty ItemsProperty =
+		public static readonly DependencyProperty ItemsProperty =
 			DependencyProperty.Register(
 				nameof(Items),
 				typeof(List<BottomNavigationBarItem>),


### PR DESCRIPTION
﻿GitHub Issue: #99

## PR Type

- Bugfix

## Description
fix BottomBarNavigation breaking navigation on second visit.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
`DependencyProperty` isnt declared with `static` modifier, so it is registered every time the owner class is instantiated instead of just once, hence why it broke on second visit.
resolved: #99