### PR TITLE
Dev/xygu/153/bottom bar navigation breaks on 2nd visit

### DIFF
--- a/src/library/Uno.Material/Controls/BottomNavigationBar.cs
+++ b/src/library/Uno.Material/Controls/BottomNavigationBar.cs
@@ -20,7 +20,7 @@ namespace Uno.Material.Controls
 				nameof(Items),
 				typeof(List<BottomNavigationBarItem>),
 				typeof(BottomNavigationBar),
-				new PropertyMetadata(new List<BottomNavigationBarItem>(), OnItemsChanged));
+				new PropertyMetadata(null, OnItemsChanged));
 
 		public BottomNavigationBarItem SelectedItem
 		{
@@ -35,9 +35,12 @@ namespace Uno.Material.Controls
 				typeof(BottomNavigationBar),
 				new PropertyMetadata(null, OnSelectedItemChanged));
 
+		private bool _initialized = false;
+
 		public BottomNavigationBar()
 		{
 			DefaultStyleKey = typeof(BottomNavigationBar);
+			Items = new List<BottomNavigationBarItem>();
 
 			Unloaded += BottomNavigationBar_Unloaded;
 		}
@@ -55,6 +58,8 @@ namespace Uno.Material.Controls
 		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
+
+			_initialized = true;
 			GenerateTabItems();
 		}
 
@@ -73,6 +78,8 @@ namespace Uno.Material.Controls
 
 		internal void GenerateTabItems()
 		{
+			if (!_initialized) return;
+
 			// Unhook events of any previous items
 			for (var i = 0; i < Items.Count; i++)
 			{

--- a/src/library/Uno.Material/Helpers/ControlHelper.cs
+++ b/src/library/Uno.Material/Helpers/ControlHelper.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.Material.Helpers
+{
+	internal static class ControlHelper
+	{
+		public static TControl GetTemplateChild<TControl>(this Control control, Func<string, DependencyObject> getTemplateChildImpl, string childName)
+#if __ANDROID__ || __IOS__ || __WASM__
+			where TControl : class, DependencyObject
+#else
+			where TControl : DependencyObject
+#endif
+		{
+			var child = getTemplateChildImpl(childName) ?? throw new Exception($"Unable to find template child ({childName}) in the control template of '{control.GetType().Name}'.");
+			return child as TControl ?? throw new InvalidCastException($"Unable to cast template child ({childName}) from type of '{child.GetType()}' to '{typeof(TControl)}'.");
+		}
+	}
+}

--- a/src/library/Uno.Material/Styles/Controls/BottomNavigationBar.xaml
+++ b/src/library/Uno.Material/Styles/Controls/BottomNavigationBar.xaml
@@ -18,7 +18,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="controls:BottomNavigationBar">
-					<Grid x:Name="PART_Grid"
+					<Grid x:Name="PART_LayoutRoot"
 						  Height="{TemplateBinding Height}"
 						  Background="{TemplateBinding Background}" />
 				</ControlTemplate>

--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/BottomNavigationBarSamplePage.xaml
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/BottomNavigationBarSamplePage.xaml
@@ -8,24 +8,24 @@
 	  mc:Ignorable="d">
 
 	<Grid>
-		<TextBlock Text="{x:Bind BottomNavBar.SelectedItem.Label, Mode=OneWay}"
+		<TextBlock Text="{x:Bind BottomNavBar.SelectedItem.Tag, Mode=OneWay}"
 				   FontWeight="Bold"
 				   HorizontalAlignment="Center"
 				   VerticalAlignment="Center" />
 
 		<controls:BottomNavigationBar x:Name="BottomNavBar">
 			<controls:BottomNavigationBar.Items>
-				<controls:BottomNavigationBarItem Label="Favorites">
+				<controls:BottomNavigationBarItem Label="Favorites" Tag="My Favorites">
 					<controls:BottomNavigationBarItem.Icon>
 						<SymbolIcon Symbol="Favorite" />
 					</controls:BottomNavigationBarItem.Icon>
 				</controls:BottomNavigationBarItem>
-				<controls:BottomNavigationBarItem Label="Search">
+				<controls:BottomNavigationBarItem Label="Search" Tag="Search Something">
 					<controls:BottomNavigationBarItem.Icon>
 						<SymbolIcon Symbol="Find" />
 					</controls:BottomNavigationBarItem.Icon>
 				</controls:BottomNavigationBarItem>
-				<controls:BottomNavigationBarItem>
+				<controls:BottomNavigationBarItem Tag="Important Stuff">
 					<controls:BottomNavigationBarItem.Icon>
 						<SymbolIcon Symbol="Important" />
 					</controls:BottomNavigationBarItem.Icon>
@@ -33,7 +33,7 @@
 						<entities:BottomNavigationBarBadge IsVisible="True" />
 					</controls:BottomNavigationBarItem.Badge>
 				</controls:BottomNavigationBarItem>
-				<controls:BottomNavigationBarItem Label="Notifications">
+				<controls:BottomNavigationBarItem Label="Notifications" Tag="12 Unread Notifications">
 					<controls:BottomNavigationBarItem.Icon>
 						<SymbolIcon Symbol="Flag" />
 					</controls:BottomNavigationBarItem.Icon>
@@ -42,7 +42,7 @@
 														   Text="12" />
 					</controls:BottomNavigationBarItem.Badge>
 				</controls:BottomNavigationBarItem>
-				<controls:BottomNavigationBarItem>
+				<controls:BottomNavigationBarItem Tag="App Settings">
 					<controls:BottomNavigationBarItem.Icon>
 						<SymbolIcon Symbol="Setting" />
 					</controls:BottomNavigationBarItem.Icon>


### PR DESCRIPTION
﻿GitHub Issue: #153

## PR Type
What kind of change does this PR introduce?

- Bugfix
- Refactoring

## Description
fix(BottomNavBar): items added again on revisit

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] ~~Tested MacOS~~
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)

## Other information
resolved: #153
