### PR TITLE
fix: ToggleSwitch shouldn't have an empty space if Header is not defined #442

### DIFF
--- a/src/library/Uno.Material/Styles/Controls/ToggleSwitch.xaml
+++ b/src/library/Uno.Material/Styles/Controls/ToggleSwitch.xaml
@@ -277,6 +277,7 @@
 						<TextBlock Text="{TemplateBinding Header}"
 								   Style="{StaticResource MaterialBody2}"
 								   Foreground="{StaticResource MaterialOnBackgroundBrush}"
+								   Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyToCollapsed},TargetNullValue=Collapsed}"
 								   Grid.ColumnSpan="4" />
 
 						<ContentPresenter x:Name="OnContentPresenter"
@@ -389,6 +390,7 @@
 										  Foreground="{StaticResource MaterialOnBackgroundBrush}"
 										  VerticalAlignment="Stretch"
 										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  Visibility="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyToCollapsed},TargetNullValue=Collapsed}"
 										  Margin="0,8,0,5" />
 
 						<!-- Do not add x:Name to BindableUiSwitch or else page will not load -->
@@ -411,7 +413,7 @@
 		<Setter Property="HorizontalContentAlignment"
 				Value="Stretch" />
 		<Setter Property="MinHeight"
-				Value="50" />
+				Value="25" />
 		<Setter Property="MinWidth"
 				Value="70" />
 
@@ -477,7 +479,7 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 
-						<!-- The margin here is used to properly align the content with the UI switch -->
+						<!-- The margin here is used to properly align the content with the UI switch -->	
 						<ContentPresenter x:Name="ContentPresenter"
 										  Content="{TemplateBinding Header}"
 										  ContentTemplate="{TemplateBinding HeaderTemplate}"
@@ -532,13 +534,13 @@
 				Value="{StaticResource MaterialPrimaryVariantLightBrush}" />
 		<Setter Property="Background"
 				Value="{StaticResource MaterialPrimaryVariantDarkBrush}" />
-		
+
 		<Setter Property="HorizontalAlignment"
 				Value="Left" />
 		<Setter Property="HorizontalContentAlignment"
 				Value="Stretch" />
 		<Setter Property="MinHeight"
-				Value="50" />
+				Value="25" />
 		<Setter Property="MinWidth"
 				Value="70" />
 
@@ -581,7 +583,7 @@
 												Value="Visible" />
 									</VisualState.Setters>
 								</VisualState>
-								
+
 								<VisualState x:Name="On">
 									<VisualState.Setters>
 										<Setter Target="AndroidSwitch.TrackTint"
@@ -662,8 +664,8 @@
 	</macos:Style>
 
 	<macos:Style x:Key="MaterialSecondaryToggleSwitchStyle"
-		   TargetType="ToggleSwitch"
-		   BasedOn="{StaticResource MaterialToggleSwitchStyle}">
+				 TargetType="ToggleSwitch"
+				 BasedOn="{StaticResource MaterialToggleSwitchStyle}">
 
 		<Setter Property="Foreground"
 				Value="{StaticResource MaterialSecondaryVariantDarkBrush}" />
@@ -672,8 +674,8 @@
 	</macos:Style>
 
 	<win:Style x:Key="MaterialSecondaryToggleSwitchStyle"
-		   TargetType="ToggleSwitch"
-		   BasedOn="{StaticResource MaterialToggleSwitchStyle}">
+			   TargetType="ToggleSwitch"
+			   BasedOn="{StaticResource MaterialToggleSwitchStyle}">
 
 		<Setter Property="Foreground"
 				Value="{StaticResource MaterialSecondaryVariantDarkBrush}" />
@@ -682,8 +684,8 @@
 	</win:Style>
 
 	<wasm:Style x:Key="MaterialSecondaryToggleSwitchStyle"
-		   TargetType="ToggleSwitch"
-		   BasedOn="{StaticResource MaterialToggleSwitchStyle}">
+				TargetType="ToggleSwitch"
+				BasedOn="{StaticResource MaterialToggleSwitchStyle}">
 
 		<Setter Property="Foreground"
 				Value="{StaticResource MaterialSecondaryVariantDarkBrush}" />
@@ -692,8 +694,8 @@
 	</wasm:Style>
 
 	<ios:Style x:Key="MaterialSecondaryToggleSwitchStyle"
-		   TargetType="ToggleSwitch"
-		   BasedOn="{StaticResource MaterialToggleSwitchStyle}">
+			   TargetType="ToggleSwitch"
+			   BasedOn="{StaticResource MaterialToggleSwitchStyle}">
 
 		<Setter Property="Foreground"
 				Value="{StaticResource MaterialSecondaryVariantDarkBrush}" />

--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/ToggleSwitchSamplePage.xaml
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/ToggleSwitchSamplePage.xaml
@@ -21,6 +21,12 @@
 					   Style="{StaticResource MaterialSubtitle2}"
 					   Margin="12,16,12,8" />
 			
+			<!-- ToggleSwitch No Label -->
+			<smtx:XamlDisplay UniqueKey="ToggleSwitchSamplePage_NoLabel"
+							  Margin="12,0">
+				<ToggleSwitch Style="{StaticResource MaterialToggleSwitchStyle}" />
+			</smtx:XamlDisplay>
+			
 			<!-- ToggleSwitch OFF -->
 			<smtx:XamlDisplay UniqueKey="ToggleSwitchSamplePage_Off"
 							  Margin="12,0">
@@ -57,6 +63,12 @@
 			<TextBlock Text="Secondary"
 					   Style="{StaticResource MaterialSubtitle2}"
 					   Margin="12,16,12,8" />
+			
+			<!-- ToggleSwitch No Label -->
+			<smtx:XamlDisplay UniqueKey="SecondaryToggleSwitchSamplePage_NoLabel"
+							  Margin="12,0">
+				<ToggleSwitch Style="{StaticResource MaterialSecondaryToggleSwitchStyle}" />
+			</smtx:XamlDisplay>
 			
 			<!-- ToggleSwitch OFF -->
 			<smtx:XamlDisplay UniqueKey="SecondaryToggleSwitchSamplePage_Off"


### PR DESCRIPTION


﻿GitHub Issue: #442

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

Make sure no space is used when the ToggleSwitch has no header

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [x] Tested iOS
- [x] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
  > If the pull request contains breaking changes, commit message must contain a detailed description of the action to take for the consumer of this library. As explained by the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
