### PR TITLE
fix(textbox_icon): The attached property were linked-out on Wasm

### DIFF
--- a/src/library/Uno.Material/LinkerConfig.xml
+++ b/src/library/Uno.Material/LinkerConfig.xml
@@ -1,0 +1,6 @@
+﻿<linker>
+	<assembly fullname="Uno.Material">
+		<!-- required for attached properties to persist -->
+		<type fullname="Uno.Material.Extensions*" />
+	</assembly>
+</linker>

--- a/src/library/Uno.Material/Uno.Material.csproj
+++ b/src/library/Uno.Material/Uno.Material.csproj
@@ -27,63 +27,9 @@
 		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 	</ItemGroup>
 	<ItemGroup>
-		<None Remove="Styles\Application\AnimationConstants.xaml" />
-		<None Remove="Styles\Application\ColorPalette.xaml" />
-		<None Remove="Styles\Application\Colors.xaml" />
-		<None Remove="Styles\Application\Converters.xaml" />
-		<None Remove="Styles\Application\TextBoxVariables.xaml" />
-		<None Remove="Styles\Controls\Chip.xaml" />
-		<None Remove="Styles\Controls\ChipGroup.xaml" />
-		<None Remove="Styles\Controls\ComboBox.xaml" />
-		<None Remove="Styles\Controls\DatePicker.xaml" />
-		<None Remove="Styles\Controls\Divider.xaml" />
-		<None Remove="Styles\Controls\ExpandingBottomSheet.xaml" />
-		<None Remove="Styles\Controls\FloatingActionButton.xaml" />
-		<None Remove="Styles\Controls\Flyout.xaml" />
-		<None Remove="Styles\Controls\HyperlinkButton.xaml" />
-		<None Remove="Styles\Controls\NavigationViewItemSeparator.xaml" />
-		<None Remove="Styles\Controls\NavigationView_PaneToggleButton.xaml" />
-		<None Remove="Styles\Controls\NavigationView_SplitView.xaml" />
-		<None Remove="Styles\Controls\PasswordBox.xaml" />
-		<None Remove="Styles\Controls\ProgressBar.xaml" />
-		<None Remove="Styles\Controls\Slider.xaml" />
-		<None Remove="Styles\Controls\Snackbar.xaml" />
-		<None Remove="Styles\Controls\NavigationView.xaml" />
-		<None Remove="Styles\Controls\StandardBottomSheet.xaml" />
-		<None Remove="Styles\Controls\TextBlock.xaml" />
-		<None Remove="Styles\Controls\TimePicker.xaml" />
-		<None Remove="Styles\Controls\ToggleButton.xaml" />
-		<None Remove="Themes\Generic.xaml" />
-	</ItemGroup>
-	<ItemGroup>
-		<UpToDateCheckInput Remove="Styles\Application\AnimationConstants.xaml" />
-		<UpToDateCheckInput Remove="Styles\Application\ColorPalette.xaml" />
-		<UpToDateCheckInput Remove="Styles\Application\Colors.xaml" />
-		<UpToDateCheckInput Remove="Styles\Application\Converters.xaml" />
-		<UpToDateCheckInput Remove="Styles\Application\TextBoxVariables.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\Chip.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\ChipGroup.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\ComboBox.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\DatePicker.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\Divider.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\ExpandingBottomSheet.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\FloatingActionButton.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\Flyout.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\HyperlinkButton.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\NavigationViewItemSeparator.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\NavigationView_PaneToggleButton.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\NavigationView_SplitView.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\Slider.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\Snackbar.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\NavigationView.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\PasswordBox.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\ProgressBar.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\StandardBottomSheet.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\TextBlock.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\TimePicker.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\ToggleButton.xaml" />
-		<UpToDateCheckInput Remove="Styles\Controls\ToggleSwitch.xaml" />
-		<UpToDateCheckInput Remove="Themes\Generic.xaml" />
+		<EmbeddedResource Include="LinkerConfig.xml">
+			<LogicalName>$(AssemblyName).xml</LogicalName>
+		</EmbeddedResource>
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="Styles\Controls\Button.xaml">

--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Shared/Content/Controls/TextBoxSamplePage.xaml
@@ -7,6 +7,7 @@
 	  xmlns:ios="http://uno.ui/ios"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
+	  xmlns:extensions="using:Uno.Material.Extensions"
 	  mc:Ignorable="d android ios">
 
 	<ScrollViewer VerticalScrollBarVisibility="Auto">
@@ -63,6 +64,17 @@
 						 Style="{StaticResource MaterialFilledTextBoxStyle}"
 						 TextWrapping="Wrap"
 						 AcceptsReturn="True" />
+			</smtx:XamlDisplay>
+
+			<!-- TexBox Icon -->
+			<smtx:XamlDisplay UniqueKey="TextBoxSamplePage_7"
+			                  Style="{StaticResource XamlDisplayBelowStyle}">
+				<TextBox PlaceholderText="Filled with Icon"
+				         Style="{StaticResource MaterialFilledTextBoxStyle}">
+					<extensions:ControlExtensions.Icon>
+						<SymbolIcon Symbol="Favorite" />
+					</extensions:ControlExtensions.Icon>
+				</TextBox>
 			</smtx:XamlDisplay>
 		</StackPanel>
 	</ScrollViewer>

--- a/src/samples/Uno.Material.Samples/Uno.Material.Samples.Wasm/Program.cs
+++ b/src/samples/Uno.Material.Samples/Uno.Material.Samples.Wasm/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Windows.UI.Xaml;
+using Uno.UI;
 
 namespace Uno.Material.Samples.Wasm
 {
@@ -9,6 +10,9 @@ namespace Uno.Material.Samples.Wasm
 
 		static int Main(string[] args)
 		{
+			FeatureConfiguration.UIElement.AssignDOMXamlName = true;
+			FeatureConfiguration.UIElement.AssignDOMXamlProperties = true;
+
 			Windows.UI.Xaml.Application.Start(_ => _app = new App());
 
 			return 0;


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/5122

# Bugfix
The `ControlExtensions.Icon` attached property were linked-out by the linker, causing the value to be impossible to read in the control template.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [X] Tested WASM
- [ ] Tested MacOS
- [X] Contains **No** breaking changes
