### PR TITLE
fix: Make ModalStandardBottomSheet collapsed by default

### DIFF
--- a/src/library/Uno.Material/Controls/ModalStandardBottomSheet.cs
+++ b/src/library/Uno.Material/Controls/ModalStandardBottomSheet.cs
@@ -74,7 +74,7 @@ namespace Uno.Material.Controls
 				VisualStateManager.GoToState(this, "Disabled", true);
 			}
 
-
+			UpdateVisualStates(true);
 
 			base.OnApplyTemplate();
 			_backdrop.PointerPressed += ToggleSheet;


### PR DESCRIPTION
﻿GitHub Issue: fixes https://github.com/unoplatform/Uno.Gallery/issues/137

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Modal sheet was initially visible when the window was resized.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- Commits must be following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tested UWP
- [ ] Tested iOS
- [ ] Tested Android
- [x] Tested WASM
- [ ] Tested MacOS
- [x] Contains **No** breaking changes
